### PR TITLE
Add questions-list partial layout back.

### DIFF
--- a/layouts/question-list.html
+++ b/layouts/question-list.html
@@ -1,0 +1,12 @@
+<section class="questions">
+  <% questions.each do |question| %>
+  <div class="question">
+    <p>
+      <a href="/question/<%= question[:original_post_id] %>/"><b><%= question[:title] %></b></a> |
+      <%= question[:answers].size %> answers |
+      <%= question[:upvote_count] %> votes | 
+      Asked by <em><%= question[:owner_display_name] %></em> in <em><%= pretty_date question[:creation_date] %></em>
+    </p>
+  </div>
+  <% end %>
+</section>


### PR DESCRIPTION
We removed this on the main question index but I didn't realize that it was in use elsewhere.
For now restore it, we'll figure out if the partial is needed or if we'll render these differently per situation.