### PR TITLE
Escape HTML in titles.

### DIFF
--- a/content/questions/index.html
+++ b/content/questions/index.html
@@ -11,7 +11,7 @@
   <% questions.each do |question| %>
   <div class="question">
     <p>
-      <a href="/question/<%= question[:original_post_id] %>/"><b><%= question[:title] %></b></a> |
+      <a href="/question/<%= question[:original_post_id] %>/"><b><%= h question[:title] %></b></a> |
       <%= question[:answers].size %> answers |
       <%= question[:upvote_count] %> votes | 
       Asked by <em><%= question[:owner_display_name] %></em> in <em><%= pretty_date question[:creation_date] %></em>

--- a/layouts/question.html
+++ b/layouts/question.html
@@ -4,7 +4,7 @@
   <body>
     <%= render '/site_header.*' %>
     <div id="main">
-      <h2><%= item[:title] %></h2>
+      <h2><%= h item[:title] %></h2>
       <div class="question">
         <% if item[:migrated_url] %>
         <p class="note migrated">This question has also been migrated to <a href="https://robotics.stackexchange.com">Robotics StackExchange</a> as <a href="<%= item[:migrated_url] %>"><%= item[:migrated_url] %></a>.</p>

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -50,7 +50,9 @@ module MarkdownHelper
   end
 end
 
+use_helper Nanoc::Helpers::HTMLEscape
 use_helper Nanoc::Helpers::Rendering
-use_helper QuestionsHelper
-use_helper MigratedPostsHelper
+
 use_helper MarkdownHelper
+use_helper MigratedPostsHelper
+use_helper QuestionsHelper


### PR DESCRIPTION
Markdown bodies are escaped when they pass through the markdown filter but the titles are raw user content and need to be escaped when rendered.