### PR TITLE
Add canonical links for questions and users.

### DIFF
--- a/layouts/html_head.html
+++ b/layouts/html_head.html
@@ -2,6 +2,11 @@
     <meta charset="utf-8">
     <title><%= @config[:site_title] %></title>
     <link rel="stylesheet" href="/stylesheet.css">
+    <% if @item.identifier =~ %r{/question/.+\.md} %>
+    <link rel="canonical" href="/question/<%= item[:original_post_id] %>">
+    <% elsif @item.identifier =~ %r{/users/.+\.md} %>
+    <link rel="canonical" href="/users/<%= item[:id] %>">
+    <% end %>
 
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">


### PR DESCRIPTION
These will help content links in search indexes update to the new supported urls for this content which don't include the username or pathified question title.