### PR TITLE
Display questions in reverse chronological order.

### DIFF
--- a/content/questions/index.html
+++ b/content/questions/index.html
@@ -8,7 +8,7 @@
 <% questions = @items.find_all "/question/*.md" %>
 <h3>All questions</h3>
 <section class="questions">
-  <% questions.each do |question| %>
+  <% questions.sort_by{|q| q[:creation_date]}.each do |question| %>
   <div class="question">
     <a href="/question/<%= question[:original_post_id] %>/"><b><%= h question[:title] %></b></a> |
     <%= question[:answers].size %> answers |


### PR DESCRIPTION
We could get more sophisticated with the index but this is a fairly straightforward way to prioritize recent questions with in-page search.