### PR TITLE
Parsing the date is required to sort this as a date.

### DIFF
--- a/content/questions/index.html
+++ b/content/questions/index.html
@@ -8,7 +8,7 @@
 <% questions = @items.find_all "/question/*.md" %>
 <h3>All questions</h3>
 <section class="questions">
-  <% questions.sort_by{|q| q[:creation_date]}.each do |question| %>
+  <% questions.sort_by{|q| DateTime.parse(q[:creation_date])}.reverse.each do |question| %>
   <div class="question">
     <a href="/question/<%= question[:original_post_id] %>/"><b><%= h question[:title] %></b></a> |
     <%= question[:answers].size %> answers |


### PR DESCRIPTION
These YAML dates are not being converted into Ruby DateTime by default and thus the sort order was based on the string values not the actual dates.