### PR TITLE
Add layout links for question index.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,3 +1,3 @@
 <h1><%= @config[:site_title] %> Answers Archive</h1>
 <p>This is the static archive of questions from <%= @config[:site_title] %> Answers</p>
-<p>Many questions were migrated to <a href="https://robotics.stackexchange.com">Robotics StackExchange</a> but those that were not, as well as other links and information related to the Q&A sites are archived here.</p>
+<p>Many questions were migrated to <a href="https://robotics.stackexchange.com">Robotics StackExchange</a> but those that were not, as well as other links and information related to the Q&A sites are archived <a href="/questions">here</a>.</p>

--- a/layouts/site_header.html
+++ b/layouts/site_header.html
@@ -1,3 +1,4 @@
   <header class="site">
     <a href="https://robotics.stackexchange.com">Robotics StackExchange</a>
+    | <a href="/questions">Archived questions</a>
   </header>


### PR DESCRIPTION
The site index didn't list the questions index. Now it does and so do each question via the header bar.